### PR TITLE
Change auth type and create an option to run without config files

### DIFF
--- a/CloneAllRepos.config
+++ b/CloneAllRepos.config
@@ -1,4 +1,2 @@
-[General] 
-Url=https://dev.azure.com/{your-organization}/{your-team-project}/
-Username=your.username
-Password=your.password
+URL=https://dev.azure.com/itst-dev/GoApps/
+PAT=blcuyodhnzp2qjyogrj62jr2k5chtrkktygxaav4rmoidjg4huda

--- a/CloneAllRepos.config
+++ b/CloneAllRepos.config
@@ -1,2 +1,2 @@
-URL=https://dev.azure.com/itst-dev/GoApps/
-PAT=blcuyodhnzp2qjyogrj62jr2k5chtrkktygxaav4rmoidjg4huda
+URL=https://dev.azure.com/{Organization}/{Team}/
+PAT={Person_Access_Token}

--- a/CloneAllRepos.ps1
+++ b/CloneAllRepos.ps1
@@ -3,41 +3,40 @@
 
 # Read configuration file
 Get-Content "CloneAllRepos.config" | foreach-object -begin { $h = @{ } } -process { 
-    $k = [regex]::split($_, '='); 
-    if (($k[0].CompareTo("") -ne 0) -and ($k[0].StartsWith("[") -ne $True)) { 
-        $h.Add($k[0], $k[1]) 
+    $k = [regex]::split($_, '=');
+    if (($k[0].CompareTo("") -ne 0) -and ($k[0].StartsWith("[") -ne $True)) {
+        $h.Add($k[0], $k[1])
     } 
 }
-$url = $h.Get_Item("Url")
-$username = $h.Get_Item("Username")
-$password = $h.Get_Item("Password")
+
+$url = $h.Get_Item("URL")
+$pat = $h.Get_Item("PAT")
 
 # Retrieve list of all repositories
-$base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $username, $password)))
+$base64AuthInfo= [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$($pat)"))
+
 $headers = @{
     "Authorization" = ("Basic {0}" -f $base64AuthInfo)
     "Accept"        = "application/json"
 }
 
-Add-Type -AssemblyName System.Web
-$gitcred = ("{0}:{1}" -f [System.Web.HttpUtility]::UrlEncode($username), $password)
-
-$resp = Invoke-WebRequest -Headers $headers -Uri ("{0}/_apis/git/repositories?api-version=1.0" -f $url) -UseBasicParsing
-$json = convertFrom-JSON $resp.Content
+$resp = Invoke-RestMethod -Method Get -Headers $headers -Uri ("{0}/_apis/git/repositories?api-version=6.0" -f $url)
 
 # Clone or pull all repositories
 $initpath = get-location
-foreach ($entry in $json.value) { 
-    $name = $entry.name 
+foreach ($entry in $resp.value) {
+    $name = $entry.name
+    $sshUrl = $entry.sshUrl
+    
     Write-Host $name
+    Write-Host $sshUrl
 
-    $url = $entry.sshUrl -replace "://", ("://{0}@" -f $gitcred)
     if (!(Test-Path -Path $name)) {
-        git clone $url
+        git clone $sshUrl
     }
     else {
         set-location $name
-        git pull  
+        git pull
         set-location $initpath
     }
 }

--- a/CloneAllReposParams.ps1
+++ b/CloneAllReposParams.ps1
@@ -1,0 +1,33 @@
+# How to execute
+# powershell -ExecutionPolicy Bypass -File ./CloneAllReposParams.ps1 -URL {Your_DevOps_URL} -PAT {Your_PAT_Token}
+
+param([parameter(mandatory)] [string] $URL, [parameter(mandatory)] [string] $PAT )
+
+# Retrieve list of all repositories
+$base64AuthInfo= [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$($PAT)"))
+
+$headers = @{
+    "Authorization" = ("Basic {0}" -f $base64AuthInfo)
+    "Accept"        = "application/json"
+}
+
+$resp = Invoke-RestMethod -Method Get -Headers $headers -Uri ("{0}/_apis/git/repositories?api-version=6.0" -f $URL)
+
+# Clone or pull all repositories
+$initpath = get-location
+foreach ($entry in $resp.value) {
+    $name = $entry.name
+    $sshUrl = $entry.sshUrl
+    
+    Write-Host $name
+    Write-Host $sshUrl
+
+    if (!(Test-Path -Path $name)) {
+        git clone $sshUrl
+    }
+    else {
+        set-location $name
+        git pull
+        set-location $initpath
+    }
+}

--- a/README.md
+++ b/README.md
@@ -40,13 +40,30 @@ Baixe os arquivos ***CloneAllRepos.config*** e ***CloneAllRepos.ps1*** na pasta 
 
 :warning: [Powershell](https://docs.microsoft.com/pt-br/powershell/scripting/install/installing-powershell?view=powershell-7)
 
+## Autenticação
+
+**Autenticação com SSH**
+
+Você precisará configurar a autenticação com SSH aos repositórios Git do Azure DevOps.
+
+[Veja como usar autenticação SSH no Azure DevOps Repos](https://docs.microsoft.com/en-us/azure/devops/repos/git/use-ssh-keys-to-authenticate?view=azure-devops)
+
+**Autenticação com PAT**
+
+Você precisará configurar um token PAT para realizar a autenticação ao Azure DevOps Repos e listar os repositórios.
+
+[Veja como usar PAT (Personal Access Token) no Azure DevOps](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=preview-page)
+
+<br>
+
+> Você precisará tanto da autenticação com ***PAT*** quanto da autenticação com ***SSH***. A primeira (***PAT***) será utilizada para autenticar no ***Azure DevOps Repos*** e listar todos os repositórios do seu projeto. Já a segunda (***SSH***) será utilizada para autenticar no servidor ***Git*** e  fazer o `clone` ou `pull` em cada repositório listado.
+
 ## Como rodar a aplicação :arrow_forward:
 
-Abra o arquivo ***CloneAllRepos.config*** no seu editor de texto preferido e altere os parâmetros ***URL***, ***username*** e ***password***.
+Abra o arquivo ***CloneAllRepos.config*** no seu editor de texto preferido e altere os parâmetros ***URL*** e ***PAT***.
 
 1. Na ***URL*** informe a URL do seu Team Project Azure Repos
-2. No ***username***, informe o seu usuário para acessar o Azure DevOps
-3. Em ***password***, informe sua senha de acesso ao Azure DevOps
+3. Em ***PAT***, informe seu Personal Access Token criado no Azure DevOps
 4. Salve e feche o arquivo
 
 No terminal, execute o script: 


### PR DESCRIPTION
Update the Clone All Repos Script to new authentication type (PAT) and create a new script to Clone All Repos with Params, without use a config file. The README file also updated to reflect new authentication type.